### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "leaflet-svgicon",
+  "version": "1.0.0",
+  "description": "SVG icon for any marker class",
+  "main": "svg-icon.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iatkin/leaflet-svgicon.git"
+  },
+  "keywords": [
+    "leaflet",
+    "svg",
+    "svgicon",
+    "marker",
+    "icon"
+  ],
+  "author": "timwis <tim@timwis.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/iatkin/leaflet-svgicon/issues"
+  },
+  "homepage": "https://github.com/iatkin/leaflet-svgicon#readme"
+}


### PR DESCRIPTION
This allows the library to be included with npm even though it's not in the npm registry, ie.

```bash
npm install iatkin/leaflet-svgicon
```

Otherwise in order to use it, you have to include the source code in your project's codebase.

I'd also suggest running `npm publish` so it's available in the registry, but that's up to you. This PR will let it work either way.